### PR TITLE
Fixes issue #17: Unable to set Release qualifier in preferences.

### DIFF
--- a/com.inventage.tools.versiontiger.ui/src/main/java/com/inventage/tools/versiontiger/ui/preferences/CustomPreferencePageSupport.java
+++ b/com.inventage.tools.versiontiger.ui/src/main/java/com/inventage/tools/versiontiger/ui/preferences/CustomPreferencePageSupport.java
@@ -3,9 +3,13 @@ package com.inventage.tools.versiontiger.ui.preferences;
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.databinding.dialog.DialogPageSupport;
+import org.eclipse.jface.databinding.preference.PreferencePageSupport;
 import org.eclipse.jface.dialogs.DialogPage;
 import org.eclipse.jface.preference.PreferencePage;
 
+/**
+ * The {@link PreferencePageSupport} of this JSF version has a bug which causes a NPE. This is why we roll our own one here. Once we update the library, we may switch back. 
+ */
 public class CustomPreferencePageSupport extends DialogPageSupport {
 
 	protected CustomPreferencePageSupport(DialogPage dialogPage, DataBindingContext dbc) {
@@ -15,9 +19,17 @@ public class CustomPreferencePageSupport extends DialogPageSupport {
 	@Override
 	protected void handleStatusChanged() {
 		super.handleStatusChanged();
-		
+		((PreferencePage) getDialogPage()).setValid(isNotStale() && hasValidStatus());
+	}
+	
+	private boolean isNotStale() {
+		return !currentStatusStale;
+	}
+	
+	private boolean hasValidStatus() {
 		if (currentStatus != null) {
-			((PreferencePage) getDialogPage()).setValid(!currentStatus.matches(IStatus.ERROR | IStatus.CANCEL));
+			return !currentStatus.matches(IStatus.ERROR | IStatus.CANCEL);
 		}
+		return true;
 	}
 }


### PR DESCRIPTION
Interestingly, this error only showed up in Juno, but not in Galileo. It appears there was a different default value handling in place or something.
