### PR TITLE
terminate after file is exhausted if invoked with a file argument

### DIFF
--- a/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/impl/Main.java
+++ b/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/impl/Main.java
@@ -16,10 +16,13 @@ public class Main {
 	public void executeCommands(String[] args) {
 		try {
 			CommandExecuter commandExecuter = new CommandExecuter(new VersioningImpl(), getCurrentDirectory(), logger);
-			executeCommandFromArgumentFile(args, commandExecuter);
-
-			System.out.println("Reading commands from standard input:");
-			commandExecuter.executeCommands(stdIn);
+			if (args.length == 1)
+				executeCommandFromArgumentFile(args, commandExecuter);
+			else if (args.length == 0) {
+				System.out.println("Reading commands from standard input:");
+				commandExecuter.executeCommands(stdIn);
+			}
+			else System.err.println("Invalid number of arguments provided");
 		} catch (IOException e) {
 			throw new IllegalStateException("Cannot read commands.", e);
 		} finally {


### PR DESCRIPTION
Causes `java -jar com.inventage.tools.versiontiger-<version>-cli filename` to terminate once all commands in filename are executed.
