### PR TITLE
Prototype for a fix for issue #55

### DIFF
--- a/com.inventage.tools.versiontiger.ui/src/main/java/com/inventage/tools/versiontiger/ui/edit/EditVersionHandler.java
+++ b/com.inventage.tools.versiontiger.ui/src/main/java/com/inventage/tools/versiontiger/ui/edit/EditVersionHandler.java
@@ -1,5 +1,7 @@
 package com.inventage.tools.versiontiger.ui.edit;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Iterator;
 import java.util.List;
 
@@ -83,7 +85,9 @@ public class EditVersionHandler extends AbstractHandler {
 				return wizard.getEditVersionModel();
 			}
 		} catch (Exception e) {
-			StatusManager.getManager().handle(new Status(Status.ERROR, VersioningUIPlugin.PLUGIN_ID, "Cannot display current project version state.", e),
+			StringWriter sw = new StringWriter();
+			e.printStackTrace(new PrintWriter(sw));
+			StatusManager.getManager().handle(new Status(Status.ERROR, VersioningUIPlugin.PLUGIN_ID, "Cannot display current project version state." + "\n" + sw.toString(), e),
 					StatusManager.SHOW);
 		}
 		return null;

--- a/com.inventage.tools.versiontiger.universedefinition/src/main/java/com/inventage/tools/versiontiger/universedefinition/workspaceprojects/AllWorkspaceProjectsUniverseProvider.java
+++ b/com.inventage.tools.versiontiger.universedefinition/src/main/java/com/inventage/tools/versiontiger/universedefinition/workspaceprojects/AllWorkspaceProjectsUniverseProvider.java
@@ -37,9 +37,13 @@ public class AllWorkspaceProjectsUniverseProvider implements ProjectUniverseProv
 		return universe;
 	}
 
+	private boolean includeClosedProjects = true;
+	
 	private void addAllWorkspaceProjects(ProjectUniverse universe) {
 		for (IProject project : getWorkspaceProjects()) {
-			universe.addProjectPath(getProjectPath(project));
+			if (includeClosedProjects || project.isOpen()) {
+				universe.addProjectPath(getProjectPath(project));
+			}
 		}
 	}
 

--- a/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/impl/AbstractEclipseProject.java
+++ b/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/impl/AbstractEclipseProject.java
@@ -1,0 +1,68 @@
+package com.inventage.tools.versiontiger.internal.impl;
+
+import java.io.File;
+
+import com.inventage.tools.versiontiger.MavenProject;
+import com.inventage.tools.versiontiger.VersioningLogger;
+
+abstract class AbstractEclipseProject extends MavenProjectImpl {
+
+	AbstractEclipseProject(String projectPath, VersioningLogger logger, VersionFactory versionFactory) {
+		super(projectPath, logger, versionFactory);
+	}
+
+	private MavenProject parentProject;
+	
+	protected MavenProject getParentProject() {
+		return parentProject;
+	}
+
+	public void setParentProject(MavenProject parentProject) {
+		this.parentProject = parentProject;
+	}
+	
+	protected boolean isPomLess() {
+		return parentProject != null;
+	}
+	
+	protected File getPomXmlFile() {
+		return (isPomLess() ? null : super.getPomXmlFile());
+	}
+
+	protected String getPomContent() {
+		if (pomContent == null && isPomLess()) {
+			pomContent = synthesisePom();
+		}
+		return super.getPomContent();
+	}
+	
+	protected String synthesisePom() {
+		return
+				"<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+				+ "\txsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n"
+				+ "\t<modelVersion>4.0.0</modelVersion>\n"
+				+ "\t<artifactId>" + getProjectId() + "</artifactId>\n"
+				+ "\t<packaging>" + getEclipsePackagingName() + "</packaging>\n"
+				+ "\n"
+				+ "\t<parent>\n"
+				+ "\t\t<groupId>" + getGroupId() + "</groupId>\n"
+				+ "\t\t<artifactId>" + getParentArtifactId() + "</artifactId>\n"
+				+ "\t\t<version>" + getParentProject().getVersion() + "</version>\n"
+				+ "\t\t<relativePath>..</relativePath>"
+				+ "\t</parent>\n"
+				+ "</project>\n"
+				;
+	}
+
+	protected abstract String getEclipsePackagingName();
+	
+	protected abstract String getProjectId();
+	
+	protected String getParentArtifactId() {
+		return getParentProject().getProperty("artifactId");
+	}
+
+	protected String getGroupId() {
+		return getParentProject().getProperty("groupId");
+	}
+}

--- a/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/impl/EclipseFeature.java
+++ b/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/impl/EclipseFeature.java
@@ -13,12 +13,22 @@ import com.inventage.tools.versiontiger.util.XmlHandler;
 import de.pdark.decentxml.Attribute;
 import de.pdark.decentxml.Element;
 
-class EclipseFeature extends MavenProjectImpl {
+class EclipseFeature extends AbstractEclipseProject {
 
 	private String featureContent;
 
 	EclipseFeature(String projectPath, VersioningLogger logger, VersionFactory versionFactory) {
 		super(projectPath, logger, versionFactory);
+	}
+
+	@Override
+	protected String getEclipsePackagingName() {
+		return "eclipse-feature";
+	}
+	
+	@Override
+	protected String getProjectId() {
+		return new XmlHandler().getElement(getFeatureXmlContent(), "feature").getAttributeValue("id");
 	}
 
 	@Override

--- a/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/impl/EclipsePlugin.java
+++ b/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/impl/EclipsePlugin.java
@@ -2,7 +2,6 @@ package com.inventage.tools.versiontiger.internal.impl;
 
 import java.io.File;
 
-import com.inventage.tools.versiontiger.internal.manifest.ManifestParser;
 import com.inventage.tools.versiontiger.MavenVersion;
 import com.inventage.tools.versiontiger.OsgiVersion;
 import com.inventage.tools.versiontiger.ProjectUniverse;
@@ -10,14 +9,39 @@ import com.inventage.tools.versiontiger.VersioningLogger;
 import com.inventage.tools.versiontiger.VersioningLoggerItem;
 import com.inventage.tools.versiontiger.VersioningLoggerStatus;
 import com.inventage.tools.versiontiger.internal.manifest.Manifest;
+import com.inventage.tools.versiontiger.internal.manifest.ManifestParser;
 import com.inventage.tools.versiontiger.util.FileHandler;
 
-class EclipsePlugin extends MavenProjectImpl {
+class EclipsePlugin extends AbstractEclipseProject {
 
 	private String manifestContent;
 	
 	EclipsePlugin(String projectPath, VersioningLogger logger, VersionFactory versionFactory) {
 		super(projectPath, logger, versionFactory);
+	}
+
+	protected boolean isTestsProject() {
+		return getProjectId().endsWith(".tests");
+	}
+
+	@Override
+	protected String getEclipsePackagingName() {
+		return "eclipse-" + (isTestsProject() ? "test-plugin" : "plugin");
+	}
+
+	@Override
+	protected String getProjectId() {
+		StringBuilder buffer = new StringBuilder();
+		parseManifest().getManifestHeader("Bundle-SymbolicName").print(buffer );
+		int start = buffer.indexOf(":"), end = buffer.lastIndexOf(";");
+		if (end > 0) {
+			buffer.setLength(end);
+		}
+		String s = buffer.toString();
+		if (start > 0) {
+			s = s.substring(start + 1);
+		}
+		return s.trim();
 	}
 
 	@Override

--- a/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/impl/EclipseRepository.java
+++ b/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/impl/EclipseRepository.java
@@ -153,6 +153,7 @@ class EclipseRepository extends MavenProjectImpl {
 
 	private List<File> getProductXmlFiles() {
 		String[] names = new File(projectPath()).list(new FilenameFilter() {
+			@Override
 			public boolean accept(File dir, String name) {
 				return name.endsWith(".product");
 			}

--- a/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/impl/ReferencesUpdater.java
+++ b/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/impl/ReferencesUpdater.java
@@ -20,15 +20,8 @@ class ReferencesUpdater implements Project {
 	}
 
 	public void setVersion(MavenVersion newVersion) {
-		if (isVersionInherited()) {
-			logWarning("Cannot set version for project that heirs version from parent.");
-			return;
-		}
-		
 		MavenVersion oldVersion = getVersion();
-
 		project.setVersion(newVersion);
-
 		projectUniverse.updateReferencesFor(project.id(), oldVersion, newVersion);
 	}
 

--- a/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/manifest/Manifest.java
+++ b/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/manifest/Manifest.java
@@ -17,6 +17,16 @@ public class Manifest {
 		return sections;
 	}
 	
+	public ManifestHeader getManifestHeader(String name) {
+		for (ManifestSection manifestSection : getSections()) {
+			ManifestHeader manifestHeader = manifestSection.getManifestHeader(name);
+			if (manifestHeader != null) {
+				return manifestHeader;
+			}
+		}
+		return null;
+	}
+
 	public void addSection(ManifestSection section) {
 		sections.add(section);
 	}

--- a/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/manifest/ManifestSection.java
+++ b/com.inventage.tools.versiontiger/src/main/java/com/inventage/tools/versiontiger/internal/manifest/ManifestSection.java
@@ -11,6 +11,15 @@ public class ManifestSection {
 
 	private final List<ManifestHeader> headers = new ArrayList<ManifestHeader>();
 
+	public ManifestHeader getManifestHeader(String name) {
+		for (ManifestHeader manifestHeader : headers) {
+			if (name.equals(manifestHeader.getName())) {
+				return manifestHeader;
+			}
+		}
+		return null;
+	}
+	
 	public void addHeader(ManifestHeader header) {
 		headers.add(header);
 	}


### PR DESCRIPTION
This is a working version, based on the design suggested in the issue. Here's a brief summary of the changes:
- A new AbstractEclipseProject includes a reference to a MavenProject, which when set indicates that this is a POM-less Eclipse project (plugin or feature).
- The ProjectFactory is extended to recognise POM-less projects using Tycho's heuristics.
- The pom.xml content (String) is generated from the information in Eclipse's meta-flea (MANIFEST.MF and feature.xml), the appropriate packaging (eclipse-plugin, eclipse-test-plugin or eclipse-feature)  and the parent pom.xml.
- The Manifest and ManifestSection classes have new methods for accessing header data, to get the Bundle-SymbolicName.
- MavenProjectImpl provides protected access to pomContent, to allow synthesising it.
- MavenProjectImpl and ReferenceUpdater must allow updating project that inherit their version, since the MANIFEST of POM-less Eclipse projects need to be updated.
- MavenProjectImpl must avoid writing to a pom.xml that doesn't exist.

You may want to provide better encapsulation, e.g. not make pomContent protected but add some setter, and provide a getBundleSymbolName method in Manifest, rather than the more generic getManifestHeader.

I testet this on a branch of my PlantUML project and it worked as expected.