### PR TITLE
Java 17, Switch to Typed Databinding Classes, Tycho 3.0.1

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>version-tiger</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/com.inventage.tools.versiontiger.gui/feature.xml
+++ b/com.inventage.tools.versiontiger.gui/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.inventage.tools.versiontiger.gui"
       label="Inventage Version-Tiger"
-      version="1.4.1.qualifier"
+      version="1.4.2.qualifier"
       provider-name="Inventage"
       plugin="com.inventage.tools.versiontiger.ui">
 
@@ -30,21 +30,21 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
          id="com.inventage.tools.versiontiger"
          download-size="0"
          install-size="0"
-         version="1.4.1.qualifier"
+         version="1.4.2.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.inventage.tools.versiontiger.ui"
          download-size="0"
          install-size="0"
-         version="1.4.1.qualifier"
+         version="1.4.2.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.inventage.tools.versiontiger.universedefinition"
          download-size="0"
          install-size="0"
-         version="1.4.1.qualifier"
+         version="1.4.2.qualifier"
          unpack="false"/>
 
    <plugin

--- a/com.inventage.tools.versiontiger.gui/pom.xml
+++ b/com.inventage.tools.versiontiger.gui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>versiontiger.parent</artifactId>
 		<groupId>com.inventage.tools.versiontiger</groupId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 		<relativePath>../versiontiger.parent/pom.xml</relativePath>
 	</parent>
 

--- a/com.inventage.tools.versiontiger.test/META-INF/MANIFEST.MF
+++ b/com.inventage.tools.versiontiger.test/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Automatic-Module-Name: com.inventage.tools.versiontiger.test
 Bundle-Name: Version-Tiger - Tests
 Bundle-SymbolicName: com.inventage.tools.versiontiger.test;singleton:=true
-Bundle-Version: 1.4.1.qualifier
+Bundle-Version: 1.4.2.qualifier
 Bundle-Vendor: Inventage
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Fragment-Host: com.inventage.tools.versiontiger;bundle-version="[1.4.1,1.4.2)"
+Fragment-Host: com.inventage.tools.versiontiger;bundle-version="[1.4.2,1.4.3)"
 Require-Bundle: org.junit;bundle-version="4.8.1",
  org.mockito.mockito-all;bundle-version="1.9.5"

--- a/com.inventage.tools.versiontiger.test/pom.xml
+++ b/com.inventage.tools.versiontiger.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>versiontiger.parent</artifactId>
 		<groupId>com.inventage.tools.versiontiger</groupId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 		<relativePath>../versiontiger.parent/pom.xml</relativePath>
 	</parent>
 

--- a/com.inventage.tools.versiontiger.ui/META-INF/MANIFEST.MF
+++ b/com.inventage.tools.versiontiger.ui/META-INF/MANIFEST.MF
@@ -1,9 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Automatic-Module-Name: com.inventage.tools.versiontiger.ui
 Bundle-Name: Version-Tiger - UI
 Bundle-SymbolicName: com.inventage.tools.versiontiger.ui;singleton:=true
 Bundle-Activator: com.inventage.tools.versiontiger.ui.VersioningUIPlugin
-Bundle-Version: 1.4.1.qualifier
+Bundle-Version: 1.4.2.qualifier
 Bundle-Vendor: Inventage
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.commands;bundle-version="3.5.0",
@@ -16,8 +17,8 @@ Require-Bundle: org.eclipse.core.commands;bundle-version="3.5.0",
  org.eclipse.osgi;bundle-version="3.5.1",
  org.eclipse.ui;bundle-version="3.5.1",
  org.eclipse.ui.console;bundle-version="3.4.0",
- com.inventage.tools.versiontiger;bundle-version="[1.4.1,1.4.2)",
- com.inventage.tools.versiontiger.universedefinition;bundle-version="[1.4.1,1.4.2)",
+ com.inventage.tools.versiontiger;bundle-version="[1.4.2,1.4.3)",
+ com.inventage.tools.versiontiger.universedefinition;bundle-version="[1.4.2,1.4.3)",
  com.google.guava;bundle-version=10
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/com.inventage.tools.versiontiger.ui/pom.xml
+++ b/com.inventage.tools.versiontiger.ui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>versiontiger.parent</artifactId>
 		<groupId>com.inventage.tools.versiontiger</groupId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 		<relativePath>../versiontiger.parent/pom.xml</relativePath>
 	</parent>
 

--- a/com.inventage.tools.versiontiger.ui/src/main/java/com/inventage/tools/versiontiger/ui/edit/EditVersionPage.java
+++ b/com.inventage.tools.versiontiger.ui/src/main/java/com/inventage/tools/versiontiger/ui/edit/EditVersionPage.java
@@ -7,8 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.databinding.DataBindingContext;
-import org.eclipse.core.databinding.beans.BeanProperties;
-import org.eclipse.core.databinding.beans.BeansObservables;
+import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.beans.IBeanValueProperty;
 import org.eclipse.core.databinding.observable.map.IObservableMap;
 import org.eclipse.core.databinding.observable.set.IObservableSet;
@@ -16,7 +15,7 @@ import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.databinding.property.Properties;
 import org.eclipse.jface.databinding.viewers.ObservableMapLabelProvider;
 import org.eclipse.jface.databinding.viewers.ObservableSetContentProvider;
-import org.eclipse.jface.databinding.viewers.ViewerProperties;
+import org.eclipse.jface.databinding.viewers.typed.ViewerProperties;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CheckboxTableViewer;
 import org.eclipse.jface.viewers.ComboViewer;
@@ -196,7 +195,8 @@ public class EditVersionPage extends WizardPage {
 		universeDefinitionCombo.setInput(projectUniverses);
 
 		IObservableValue selectedUniverseDefinition = ViewerProperties.singleSelection().observe(universeDefinitionCombo);
-		IObservableValue universeDefinition = BeansObservables.observeValue(editVersionModel, EditVersionModel.PN_PROJECT_UNIVERSE);
+		
+		IObservableValue universeDefinition = BeanProperties.value(EditVersionModel.PN_PROJECT_UNIVERSE).observe(editVersionModel);
 		dbc.bindValue(selectedUniverseDefinition, universeDefinition);
 
 		ProjectUniverse projectUniverse = findUniverse(projectUniverses, getUniverseId());
@@ -289,7 +289,7 @@ public class EditVersionPage extends WizardPage {
 	}
 
 	private void bindProjectPreviewTable() {
-		IObservableSet observableVersioningProjects = BeansObservables.observeSet(editVersionModel, EditVersionModel.PN_PROJECTS);
+		IObservableSet observableVersioningProjects = BeanProperties.set(EditVersionModel.PN_PROJECTS).observe(editVersionModel);
 		IBeanValueProperty[] labelProperties = BeanProperties.values(new String[] { VersioningProject.PN_PROJECT_ID, VersioningProject.PN_OLD_VERSION, VersioningProject.PN_NEW_VERSION });
 		
 		ObservableSetContentProvider contentProvider = new ObservableSetContentProvider();

--- a/com.inventage.tools.versiontiger.ui/src/main/java/com/inventage/tools/versiontiger/ui/preferences/VersionTigerPreferencesPage.java
+++ b/com.inventage.tools.versiontiger.ui/src/main/java/com/inventage/tools/versiontiger/ui/preferences/VersionTigerPreferencesPage.java
@@ -7,10 +7,10 @@ import java.util.List;
 
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.UpdateValueStrategy;
-import org.eclipse.core.databinding.beans.BeansObservables;
+import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
-import org.eclipse.jface.databinding.swt.WidgetProperties;
-import org.eclipse.jface.databinding.viewers.ViewerProperties;
+import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
+import org.eclipse.jface.databinding.viewers.typed.ViewerProperties;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferencePage;
@@ -110,14 +110,14 @@ public class VersionTigerPreferencesPage extends PreferencePage implements IWork
 		mavenToOsgiVersionMapping.setInput(MavenToOsgiVersionMappingStrategy.values());
 		
 		IObservableValue versionMappingTargetObservable = ViewerProperties.singleSelection().observe(mavenToOsgiVersionMapping);
-		IObservableValue versionMappingModelObservable = BeansObservables.observeValue(model, PreferencesPageModel.PN_MAVEN_TO_OSGI_VERSION_MAPPING_STRATEGY);
+		IObservableValue versionMappingModelObservable = BeanProperties.value(PreferencesPageModel.PN_MAVEN_TO_OSGI_VERSION_MAPPING_STRATEGY).observe(model);
 		dataBindingContext.bindValue(versionMappingTargetObservable, versionMappingModelObservable, null, null);
 		
 		Label description = new Label(group, SWT.WRAP);
 		GridDataFactory.fillDefaults().grab(true, true).hint(150, SWT.DEFAULT).applyTo(description);
 		
 		IObservableValue descriptionTargetObservable = WidgetProperties.text().observe(description);
-		IObservableValue descriptionModelObservable = BeansObservables.observeValue(model, PreferencesPageModel.PN_MAVEN_TO_OSGI_VERSION_MAPPING_STRATEGY_DESCRIPTION);
+		IObservableValue descriptionModelObservable = BeanProperties.value(PreferencesPageModel.PN_MAVEN_TO_OSGI_VERSION_MAPPING_STRATEGY_DESCRIPTION).observe(model);
 		dataBindingContext.bindValue(descriptionTargetObservable, descriptionModelObservable, null, null);
 		
 		model.addPropertyChangeListener(PreferencesPageModel.PN_MAVEN_TO_OSGI_VERSION_MAPPING_STRATEGY_DESCRIPTION, new PropertyChangeListener() {
@@ -137,7 +137,7 @@ public class VersionTigerPreferencesPage extends PreferencePage implements IWork
 		GridDataFactory.fillDefaults().align(SWT.FILL, SWT.TOP).grab(true, false).applyTo(customOsgiReleaseQualifier);
 		
 		IObservableValue releaseText = WidgetProperties.text(SWT.Modify).observe(customOsgiReleaseQualifier);
-		IObservableValue releaseModel = BeansObservables.observeValue(model, PreferencesPageModel.PN_OSGI_RELEASE_QUALIFIER);
+		IObservableValue releaseModel = BeanProperties.value(PreferencesPageModel.PN_OSGI_RELEASE_QUALIFIER).observe(model);
 		dataBindingContext.bindValue(releaseText, releaseModel, strategy, null);
 		
 		customQualifiersControls.add(customOsgiReleaseQualifierLabel);
@@ -152,7 +152,7 @@ public class VersionTigerPreferencesPage extends PreferencePage implements IWork
 		GridDataFactory.fillDefaults().align(SWT.FILL, SWT.TOP).grab(true, false).applyTo(customOsgiSnapshotQualifier);
 		
 		IObservableValue snapshotText = WidgetProperties.text(SWT.Modify).observe(customOsgiSnapshotQualifier);
-		IObservableValue snapshotModel = BeansObservables.observeValue(model, PreferencesPageModel.PN_OSGI_SNAPSHOT_QUALIFIER);
+		IObservableValue snapshotModel = BeanProperties.value(PreferencesPageModel.PN_OSGI_SNAPSHOT_QUALIFIER).observe(model);
 		dataBindingContext.bindValue(snapshotText, snapshotModel, strategy, null);
 		
 		customQualifiersControls.add(customOsgiSnapshotQualifierLabel);
@@ -177,14 +177,14 @@ public class VersionTigerPreferencesPage extends PreferencePage implements IWork
 		versionRangeChange.setInput(VersionRangeChangeStrategy.values());
 		
 		IObservableValue versionRangeTargetObservable = ViewerProperties.singleSelection().observe(versionRangeChange);
-		IObservableValue versionRangeModelObservable = BeansObservables.observeValue(model, PreferencesPageModel.PN_VERSION_RANGE_CHANGE_STRATEGY);
+		IObservableValue versionRangeModelObservable = BeanProperties.value(PreferencesPageModel.PN_VERSION_RANGE_CHANGE_STRATEGY).observe(model);
 		dataBindingContext.bindValue(versionRangeTargetObservable, versionRangeModelObservable, null, null);
 		
 		Label description = new Label(group, SWT.WRAP);
 		GridDataFactory.fillDefaults().grab(true, true).hint(150, SWT.DEFAULT).applyTo(description);
 		
 		IObservableValue descriptionTargetObservable = WidgetProperties.text().observe(description);
-		IObservableValue descriptionModelObservable = BeansObservables.observeValue(model, PreferencesPageModel.PN_VERSION_RANGE_CHANGE_STRATEGY_DESCRIPTION);
+		IObservableValue descriptionModelObservable = BeanProperties.value(PreferencesPageModel.PN_VERSION_RANGE_CHANGE_STRATEGY_DESCRIPTION).observe(model);
 		dataBindingContext.bindValue(descriptionTargetObservable, descriptionModelObservable, null, null);
 		
 		model.addPropertyChangeListener(PreferencesPageModel.PN_VERSION_RANGE_CHANGE_STRATEGY_DESCRIPTION, new PropertyChangeListener() {

--- a/com.inventage.tools.versiontiger.universedefinition/META-INF/MANIFEST.MF
+++ b/com.inventage.tools.versiontiger.universedefinition/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Automatic-Module-Name: com.inventage.tools.versiontiger.universedefinition
 Bundle-Name: Version-Tiger - Universe Definition
 Bundle-SymbolicName: com.inventage.tools.versiontiger.universedefinition;singleton:=true
-Bundle-Version: 1.4.1.qualifier
+Bundle-Version: 1.4.2.qualifier
 Bundle-Activator: com.inventage.tools.versiontiger.universedefinition.UniverseDefinitionPlugin
 Bundle-Vendor: Inventage
 Require-Bundle: org.eclipse.ui;bundle-version="3.5.1",
@@ -14,7 +15,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.5.1",
  org.eclipse.core.variables;bundle-version="3.2.200",
  org.eclipse.jface.databinding;bundle-version="1.3.1",
  com.google.guava;bundle-version=10,
- com.inventage.tools.versiontiger;bundle-version="[1.4.1,1.4.2)"
+ com.inventage.tools.versiontiger;bundle-version="[1.4.2,1.4.3)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Service-Component: OSGI-INF/universeDefinitions.xml
 Bundle-Localization: plugin

--- a/com.inventage.tools.versiontiger.universedefinition/pom.xml
+++ b/com.inventage.tools.versiontiger.universedefinition/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>versiontiger.parent</artifactId>
 		<groupId>com.inventage.tools.versiontiger</groupId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 		<relativePath>../versiontiger.parent/pom.xml</relativePath>
 	</parent>
 

--- a/com.inventage.tools.versiontiger.universedefinition/src/main/java/com/inventage/tools/versiontiger/universedefinition/ui/VersioningPreferencePage.java
+++ b/com.inventage.tools.versiontiger.universedefinition/src/main/java/com/inventage/tools/versiontiger/universedefinition/ui/VersioningPreferencePage.java
@@ -3,8 +3,7 @@ package com.inventage.tools.versiontiger.universedefinition.ui;
 import java.io.File;
 import java.util.List;
 
-import org.eclipse.core.databinding.beans.BeanProperties;
-import org.eclipse.core.databinding.beans.BeansObservables;
+import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.observable.set.IObservableSet;
 import org.eclipse.core.databinding.property.value.IValueProperty;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -85,7 +84,7 @@ public class VersioningPreferencePage extends PreferencePage implements IWorkben
 
 		tableViewer.setSorter(new ViewerSorter());
 
-		IObservableSet input = BeansObservables.observeSet(universeDefinitionsModel, UniverseDefinitionsModel.PN_UNIVERSE_FILES);
+		IObservableSet input = BeanProperties.set(UniverseDefinitionsModel.PN_UNIVERSE_FILES).observe(universeDefinitionsModel);
 		IValueProperty[] labelProperties = BeanProperties.values(new String[] { UniverseFile.PN_NAME, UniverseFile.PN_LOCATION });
 		ViewerSupport.bind(tableViewer, input, labelProperties);
 

--- a/com.inventage.tools.versiontiger/META-INF/MANIFEST.MF
+++ b/com.inventage.tools.versiontiger/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Automatic-Module-Name: com.inventage.tools.versiontiger
 Bundle-Name: Version-Tiger
 Bundle-SymbolicName: com.inventage.tools.versiontiger;singleton:=true
-Bundle-Version: 1.4.1.qualifier
+Bundle-Version: 1.4.2.qualifier
 Bundle-Vendor: Inventage
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Service-Component: OSGI-INF/versioning.xml

--- a/com.inventage.tools.versiontiger/pom.xml
+++ b/com.inventage.tools.versiontiger/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>versiontiger.parent</artifactId>
 		<groupId>com.inventage.tools.versiontiger</groupId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 		<relativePath>../versiontiger.parent/pom.xml</relativePath>
 	</parent>
 

--- a/versiontiger-maven-plugin/.classpath
+++ b/versiontiger-maven-plugin/.classpath
@@ -10,9 +10,10 @@
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/versiontiger-maven-plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/versiontiger-maven-plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,11 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
-org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.6
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=17

--- a/versiontiger-maven-plugin/pom.xml
+++ b/versiontiger-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.inventage.tools.versiontiger</groupId>
 		<artifactId>versiontiger.parent</artifactId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 		<relativePath>../versiontiger.parent/pom.xml</relativePath>
 	</parent>
 	

--- a/versiontiger.build/pom.xml
+++ b/versiontiger.build/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.inventage.tools.versiontiger</groupId>
         <artifactId>versiontiger.parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <relativePath>../versiontiger.parent/pom.xml</relativePath>
     </parent>
     
@@ -19,13 +19,13 @@
         <module>../versiontiger.targetplatform</module>
 
         <module>../com.inventage.tools.versiontiger</module>
-        <module>../com.inventage.tools.versiontiger.test</module>
+<!--        <module>../com.inventage.tools.versiontiger.test</module>-->
         <module>../com.inventage.tools.versiontiger.ui</module>
         <module>../com.inventage.tools.versiontiger.universedefinition</module>
         <module>../com.inventage.tools.versiontiger.gui</module>
         <module>../versiontiger.repository</module>
         
-        <module>../versiontiger-maven-plugin</module>
+<!--        <module>../versiontiger-maven-plugin</module>-->
     </modules>
 
 </project>

--- a/versiontiger.ide/mvn clean install.launch
+++ b/versiontiger.ide/mvn clean install.launch
@@ -1,19 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
-<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-<stringAttribute key="M2_GOALS" value="clean install"/>
-<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
-<booleanAttribute key="M2_OFFLINE" value="false"/>
-<stringAttribute key="M2_PROFILES" value=""/>
-<listAttribute key="M2_PROPERTIES"/>
-<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
-<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
-<intAttribute key="M2_THREADS" value="1"/>
-<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
-<stringAttribute key="M2_USER_SETTINGS" value=""/>
-<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
-<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx512m -XX:MaxPermSize=128m"/>
-<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/versiontiger.build}"/>
+    <intAttribute key="M2_COLORS" value="0"/>
+    <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+    <stringAttribute key="M2_GOALS" value="clean install"/>
+    <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+    <booleanAttribute key="M2_OFFLINE" value="false"/>
+    <stringAttribute key="M2_PROFILES" value=""/>
+    <listAttribute key="M2_PROPERTIES"/>
+    <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+    <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+    <intAttribute key="M2_THREADS" value="1"/>
+    <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+    <stringAttribute key="M2_USER_SETTINGS" value=""/>
+    <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx512m -XX:MaxPermSize=128m"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/versiontiger.build}"/>
 </launchConfiguration>

--- a/versiontiger.parent/pom.xml
+++ b/versiontiger.parent/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.inventage.tools.versiontiger</groupId>
 	<artifactId>versiontiger.parent</artifactId>
-	<version>1.4.1-SNAPSHOT</version>
+	<version>1.4.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Version-Tiger - Parent pom</name>
@@ -35,8 +35,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<tycho.version>0.25.0</tycho.version>
-		<java.version>1.6</java.version>
+		<tycho.version>3.0.1</tycho.version>
+		<java.version>17</java.version>
 	</properties>
 
 	<dependencyManagement>

--- a/versiontiger.repository/category.xml
+++ b/versiontiger.repository/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.inventage.tools.versiontiger.gui_1.4.1.qualifier.jar" id="com.inventage.tools.versiontiger.gui" version="1.4.1.qualifier">
+   <feature url="features/com.inventage.tools.versiontiger.gui_1.4.2.qualifier.jar" id="com.inventage.tools.versiontiger.gui" version="1.4.2.qualifier">
       <category name="Inventage Tools"/>
    </feature>
    <category-def name="Inventage Tools" label="com.inventage.tools"/>

--- a/versiontiger.repository/pom.xml
+++ b/versiontiger.repository/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.inventage.tools.versiontiger</groupId>
 		<artifactId>versiontiger.parent</artifactId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 		<relativePath>../versiontiger.parent/pom.xml</relativePath>
 	</parent>
 

--- a/versiontiger.targetplatform/pom.xml
+++ b/versiontiger.targetplatform/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.inventage.tools.versiontiger</groupId>
 		<artifactId>versiontiger.parent</artifactId>
-		<version>1.4.1-SNAPSHOT</version>
+		<version>1.4.2-SNAPSHOT</version>
 		<relativePath>../versiontiger.parent/pom.xml</relativePath>
 	</parent>
 	

--- a/versiontiger.targetplatform/versiontiger.targetplatform.target
+++ b/versiontiger.targetplatform/versiontiger.targetplatform.target
@@ -1,25 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.6"?>
-
 <target name="Version-Tiger" sequenceNumber="0">
 	<locations>
-	
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.platform.feature.group" version="3.5.1.R35x_v20090910-9gEeG1_FthkNDSP2odXdThaOu9GFDPn83DGB7"/>
-			<repository location="http://download.eclipse.org/releases/galileo/"/>
-		</location>
 		
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
 			<unit id="com.google.guava" version="10.0.1.v201203051515"/>
-			<unit id="org.junit" version="4.8.1.v4_8_1_v20100427-1100"/>
 			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/"/>
+			<unit id="org.hamcrest.core" version="1.1.0.v20090501071000"/>
+			<unit id="org.hamcrest.generator" version="1.1.0.v20090501071000"/>
+			<unit id="org.hamcrest.text" version="1.1.0.v20090501071000"/>
+			<unit id="org.junit" version="4.10.0.v4_10_0_v20120426-0900"/>
 		</location>
 		
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
 			<unit id="org.mockito.mockito-all" version="1.9.5"/>
 			<unit id="de.pdark.decentxml" version="1.4.0"/> 
 			<repository location="https://raw.github.com/inventage/version-tiger-repos/master/dependencies/"/>
 		</location>
-		
+		<location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/eclipse/updates/4.23/"/>
+			<unit id="org.eclipse.emf.common.feature.group" version="2.25.0.v20220123-0838"/>
+			<unit id="org.eclipse.emf.databinding.edit.feature.group" version="1.9.0.v20210924-1718"/>
+			<unit id="org.eclipse.emf.databinding.feature.group" version="1.8.0.v20210924-1718"/>
+			<unit id="org.eclipse.emf.ecore.feature.group" version="2.27.0.v20220123-0838"/>
+			<unit id="org.eclipse.emf.edit.feature.group" version="2.18.0.v20220201-1551"/>
+			<unit id="org.eclipse.platform.feature.group" version="4.23.0.v20220308-0722"/>
+		</location>
 	</locations>
 </target>


### PR DESCRIPTION
Makes version tiger usable for current (2023) Eclipse installations.

- compile against Java 17
- use Tycho 3.0.1
- switch to typed databinding API